### PR TITLE
Add status created as a import status

### DIFF
--- a/src/CourseService.php
+++ b/src/CourseService.php
@@ -43,6 +43,7 @@ class CourseService{
 	
 	private $_configuration = null;
 
+	const CREATED = "created";
 	const RUNNING = "running";
 	const FINISHED = "finished";
 	const ERROR = "error";
@@ -411,6 +412,7 @@ class CourseService{
                 $xmlStatus = $this->getAsyncImportStatus($token);
                 $statusResult = (string) $xmlStatus->status;
                 switch ($statusResult) {
+                    case $this::CREATED:
                     case $this::RUNNING:
                         sleep(5);
                         break;


### PR DESCRIPTION
The server returns to us a created status which wasn't listed on their documentation.